### PR TITLE
adding multi read at once and enhanceing the filteration

### DIFF
--- a/src/modules/notification/notification.controllers.js
+++ b/src/modules/notification/notification.controllers.js
@@ -12,19 +12,41 @@ export const getAll = async (req, res, next) => {
 };
 export const updateRead = async (req, res, next) => {
   try {
-    const id = req.auth.relatedId ? req.auth.relatedId : req.auth.id;
-    const notificationIds = req.body;
+    const recipientId = req.auth.relatedId ?? req.auth.id;
     const userType = req.auth.role;
+
+    const { notificationIds, markAs = "read" } = req.body;
+
     await notificationServices.updateRead({
-      recipientId: id,
+      recipientId,
       userType,
       notificationIds,
+      markAs,
     });
-    res.status(200).json({ message: "Notification updated successfully" });
+
+    res.status(200).json({
+      message: `Notification marked as ${markAs} successfully`,
+    });
   } catch (error) {
     next(error);
   }
 };
-const notificationController = { getAll, updateRead };
+export const markAllAsRead = async (req, res, next) => {
+  try {
+    const id = req.auth.relatedId ? req.auth.relatedId : req.auth.id;
+    const userType = req.auth.role;
+    await notificationServices.updateRead({
+      recipientId: id,
+      userType,
+      all: true,
+    });
+    res
+      .status(200)
+      .json({ success: true, message: "All notifications marked as read" });
+  } catch (error) {
+    next(error);
+  }
+};
+const notificationController = { getAll, updateRead, markAllAsRead };
 
 export default notificationController;

--- a/src/modules/notification/notification.controllers.js
+++ b/src/modules/notification/notification.controllers.js
@@ -13,12 +13,12 @@ export const getAll = async (req, res, next) => {
 export const updateRead = async (req, res, next) => {
   try {
     const id = req.auth.relatedId ? req.auth.relatedId : req.auth.id;
-    const notificationId = req.params.id;
+    const notificationIds = req.body;
     const userType = req.auth.role;
     await notificationServices.updateRead({
       recipientId: id,
       userType,
-      notificationId,
+      notificationIds,
     });
     res.status(200).json({ message: "Notification updated successfully" });
   } catch (error) {

--- a/src/modules/notification/notification.repository.js
+++ b/src/modules/notification/notification.repository.js
@@ -10,16 +10,10 @@ export const getAll = async (limit = 10, offset = 0, filters) => {
   });
   return [rows, count];
 };
-/**
- * Updates the read status of a notification.
- *
- * @param {string} id - the id of the notification
- * @param {string} recipientId - the id of the recipient
- * @returns {Promise<void>} - a promise that resolves when the operation is complete
- */
-export const updateRead = async (filters) => {
+
+export const updateRead = async (filters, isRead = true) => {
   return await db.Notification.update(
-    { isRead: true },
+    { isRead },
     {
       where: filters,
     },

--- a/src/modules/notification/notification.routes.js
+++ b/src/modules/notification/notification.routes.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import notificationController from "./notification.controllers.js";
 import jwtUtils from "../../middlewares/jwt.middleware.js";
+import { validateExpress } from "../../middlewares/expressValidator.js";
+import { validateUpdateRead } from "./notification.validation.js";
 const notificationRouter = Router();
 
 notificationRouter.get(
@@ -8,9 +10,21 @@ notificationRouter.get(
   jwtUtils.authenticateJwt,
   notificationController.getAll,
 );
+
+//update as read should add in the validation read and unread only
 notificationRouter.put(
-  "/updateAsRead",
+  "/updateRead",
+
   jwtUtils.authenticateJwt,
+  validateUpdateRead,
+  validateExpress,
   notificationController.updateRead,
+);
+
+//mark all as read
+notificationRouter.put(
+  "/markAllAsRead",
+  jwtUtils.authenticateJwt,
+  notificationController.markAllAsRead,
 );
 export default notificationRouter;

--- a/src/modules/notification/notification.routes.js
+++ b/src/modules/notification/notification.routes.js
@@ -9,7 +9,7 @@ notificationRouter.get(
   notificationController.getAll,
 );
 notificationRouter.put(
-  "/:id",
+  "/updateAsRead",
   jwtUtils.authenticateJwt,
   notificationController.updateRead,
 );

--- a/src/modules/notification/notification.services.js
+++ b/src/modules/notification/notification.services.js
@@ -74,7 +74,7 @@ export const updateRead = async ({
   const filters = buildRecipientFilters(recipientId, userType);
   const isRead = markAs === "read" ? true : false;
   if (all) {
-    return await notificationRepository.updateRead(filters, { isRead });
+    return await notificationRepository.updateRead(filters, isRead);
   }
   if (!notificationIds || notificationIds.length === 0) {
     throw new AppError(400, "notificationIds are required", true);

--- a/src/modules/notification/notification.services.js
+++ b/src/modules/notification/notification.services.js
@@ -47,32 +47,57 @@ export const getAll = async (id, userType, query) => {
   return { notifications: sanitizedNotifications, meta };
 };
 
+const buildRecipientFilters = (recipientId, userType) => {
+  const filters = {};
+
+  if (userType === "client") {
+    filters.userId = recipientId;
+  }
+
+  if (
+    userType === "service_provider_root" ||
+    userType === "service_provider_rep"
+  ) {
+    filters.serviceProviderId = recipientId;
+  }
+
+  return filters;
+};
+
 export const updateRead = async ({
   recipientId,
   userType,
   notificationIds,
+  all = false,
+  markAs = "read",
 }) => {
+  const filters = buildRecipientFilters(recipientId, userType);
+  const isRead = markAs === "read" ? true : false;
+  if (all) {
+    return await notificationRepository.updateRead(filters, { isRead });
+  }
+  if (!notificationIds || notificationIds.length === 0) {
+    throw new AppError(400, "notificationIds are required", true);
+  }
+
   const decodedNotificationIds = notificationIds.map((id) =>
     hashIdUtil.hashIdDecode(id),
   );
-  const filters = { id: decodedNotificationIds };
-  if (userType === "client") filters.userId = recipientId;
-  if (
-    userType === "service_provider_root" ||
-    userType === "service_provider_rep"
-  )
-    filters.serviceProviderId = recipientId;
-  if (userType === "admin" || userType === "super_admin")
-    filters.isAdmin = true;
-  const notification = await notificationRepository.updateRead(filters);
-  if (!notification[0])
+
+  filters.id = decodedNotificationIds;
+  console.log(isRead);
+  const result = await notificationRepository.updateRead(filters, isRead);
+
+  if (!result[0]) {
     throw new AppError(
       404,
       "Notification not found",
       true,
       "Notification not found",
     );
-  return notification;
+  }
+
+  return result;
 };
 
 const notificationServices = { getAll, updateRead };

--- a/src/modules/notification/notification.services.js
+++ b/src/modules/notification/notification.services.js
@@ -19,8 +19,11 @@ export const getAll = async (id, userType, query) => {
     userType === "service_provider_rep"
   )
     filters.serviceProviderId = id;
-  if (query.isRead !== undefined) {
+
+  if (query.isRead !== "all") {
     filters.isRead = query.isRead === "true";
+    if (query.isRead === "false" || query.isRead === undefined)
+      filters.isRead = false;
   }
   const [rows, count] = await notificationRepository.getAll(
     limit,
@@ -44,9 +47,15 @@ export const getAll = async (id, userType, query) => {
   return { notifications: sanitizedNotifications, meta };
 };
 
-export const updateRead = async ({ recipientId, userType, notificationId }) => {
-  const notificationIdDecoded = hashIdUtil.hashIdDecode(notificationId);
-  const filters = { id: notificationIdDecoded };
+export const updateRead = async ({
+  recipientId,
+  userType,
+  notificationIds,
+}) => {
+  const decodedNotificationIds = notificationIds.map((id) =>
+    hashIdUtil.hashIdDecode(id),
+  );
+  const filters = { id: decodedNotificationIds };
   if (userType === "client") filters.userId = recipientId;
   if (
     userType === "service_provider_root" ||

--- a/src/modules/notification/notification.swagger.yaml
+++ b/src/modules/notification/notification.swagger.yaml
@@ -76,11 +76,17 @@
                         type: integer
                         example: 1
 
-/notification/updateAsRead:
+/notification/updateRead:
   put:
     tags:
       - Notification
-    summary: Mark notifications as read (receives an array of IDs)
+    summary: Update notification read status
+    description: |
+      Mark specific notifications as read or unread.
+
+      - If `markAs` is not provided or undefined, notifications will be marked as `read` by default.
+      - Allowed values for `markAs` are `read` and `unread`.
+      - Sending any other value will result in a 422 Unprocessable Entity error.
     security:
       - bearerAuth: []
     requestBody:
@@ -88,10 +94,66 @@
       content:
         application/json:
           schema:
-            type: array
-            description: Array of hashed notification IDs
-            items:
-              type: string
+            type: object
+            required:
+              - notificationIds
+            properties:
+              notificationIds:
+                type: array
+                description: Array of hashed notification IDs
+                items:
+                  type: string
+                example:
+                  - "hashId1"
+                  - "hashId2"
+              markAs:
+                type: string
+                description: Status to mark notifications. Defaults to `read` if not provided.
+                enum:
+                  - read
+                  - unread
+                example: read
     responses:
       "200":
-        description: Successful response
+        description: Notifications updated successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: Notifications updated successfully
+      "422":
+        description: Invalid `markAs` value
+      "401":
+        description: Unauthorized
+      "404":
+        description: Notification not found
+
+/notification/markAllAsRead:
+  put:
+    tags:
+      - Notification
+    summary: Mark all notifications as read
+    description: Marks all unread notifications for the authenticated user as read.
+    security:
+      - bearerAuth: []
+    responses:
+      "200":
+        description: All notifications successfully marked as read
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                success:
+                  type: boolean
+                  example: true
+                message:
+                  type: string
+                  example: All notifications marked as read
+      "401":
+        description: Unauthorized
+      "500":
+        description: Internal server error

--- a/src/modules/notification/notification.swagger.yaml
+++ b/src/modules/notification/notification.swagger.yaml
@@ -22,8 +22,8 @@
       - in: query
         name: isRead
         schema:
-          type: boolean
-          example: true
+          type: string
+          enum: [true, false, all]
         required: false
         description: Filter by read status
       - in: query
@@ -39,21 +39,59 @@
         content:
           application/json:
             schema:
-              $ref: "../../openapi/components/schemas.yaml#/NotificationAllResponse"
+              NotificationAllResponse:
+                type: object
+                properties:
+                  notification:
+                    type: array
+                    description: Array of notification objects
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          example: "X2QA"
+                        type:
+                          type: string
+                          example: "info"
+                        message:
+                          type: string
+                          example: "You have a new order"
+                        createdAt:
+                          type: string
+                          format: date-time
+                  metadata:
+                    type: object
+                    properties:
+                      total:
+                        type: integer
+                        example: 10
+                      page:
+                        type: integer
+                        example: 1
+                      limit:
+                        type: integer
+                        example: 10
+                      totalPages:
+                        type: integer
+                        example: 1
 
-/notification/{id}:
+/notification/updateAsRead:
   put:
-    tags: [Notification]
-    summary: Mark nonfiction as read
+    tags:
+      - Notification
+    summary: Mark notifications as read (receives an array of IDs)
     security:
       - bearerAuth: []
-    parameters:
-      - name: id
-        in: path
-        required: true
-        description: The hashed notification ID
-        schema:
-          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: array
+            description: Array of hashed notification IDs
+            items:
+              type: string
     responses:
       "200":
         description: Successful response

--- a/src/modules/notification/notification.validation.js
+++ b/src/modules/notification/notification.validation.js
@@ -1,0 +1,13 @@
+import { body } from "express-validator";
+export const validateUpdateRead = [
+  //cant be empty array or less than one length
+  body("notificationIds")
+    .isArray({ min: 1 })
+    .withMessage(
+      "notificationIds must be an array and must have at least one id",
+    ),
+  body("markAs")
+    .optional()
+    .isIn(["read", "unread"])
+    .withMessage('markAs must be either "read" or "unread"'),
+];

--- a/src/openapi/components/schemas.yaml
+++ b/src/openapi/components/schemas.yaml
@@ -152,42 +152,7 @@ MetaResponse:
     message:
       type: string
       example: "Server is awake"
-NotificationAllResponse:
-  type: object
-  properties:
-    notification:
-      type: array
-      description: Array of notification objects
-      items:
-        type: object
-        properties:
-          id:
-            type: string
-            example: "X2QA"
-          type:
-            type: string
-            example: "info"
-          message:
-            type: string
-            example: "You have a new order"
-          createdAt:
-            type: string
-            format: date-time
-    metadata:
-      type: object
-      properties:
-        total:
-          type: integer
-          example: 10
-        page:
-          type: integer
-          example: 1
-        limit:
-          type: integer
-          example: 10
-        totalPages:
-          type: integer
-          example: 1
+
 OrderResponse:
   oneOf:
     - $ref: "#/OrderResponsePayout"

--- a/src/openapi/openapi.yaml
+++ b/src/openapi/openapi.yaml
@@ -29,8 +29,8 @@ paths:
     $ref: "../modules/disputes/dispute.swagger.yaml#/~1dispute~1{id}~1cancel"
   /notification:
     $ref: "../modules/notification/notification.swagger.yaml#/~1notification"
-  /notification/{id}:
-    $ref: "../modules/notification/notification.swagger.yaml#/~1notification~1{id}"
+  /notification/updateAsRead:
+    $ref: "../modules/notification/notification.swagger.yaml#/~1notification~1updateAsRead"
   /user:
     $ref: "../modules/user/user.swagger.yaml#/~1user"
   /user/admin:

--- a/src/openapi/openapi.yaml
+++ b/src/openapi/openapi.yaml
@@ -29,8 +29,10 @@ paths:
     $ref: "../modules/disputes/dispute.swagger.yaml#/~1dispute~1{id}~1cancel"
   /notification:
     $ref: "../modules/notification/notification.swagger.yaml#/~1notification"
-  /notification/updateAsRead:
-    $ref: "../modules/notification/notification.swagger.yaml#/~1notification~1updateAsRead"
+  /notification/updateRead:
+    $ref: "../modules/notification/notification.swagger.yaml#/~1notification~1updateRead"
+  /notification/markAllAsRead:
+    $ref: "../modules/notification/notification.swagger.yaml#/~1notification~1markAllAsRead"
   /user:
     $ref: "../modules/user/user.swagger.yaml#/~1user"
   /user/admin:


### PR DESCRIPTION
Enhanced the update as read endpoint to accept an array of ids and can also read and unread swagger documentation available
Enhanced the filters of fetching 
new endpoint for mark all as read `/notification/markAllAsRead`

Change log :
1. for the first route fetching notifications `/api/notifications` method `GET`, the query `isRead.`
    * case (false, undefined) returns not read
    * case (true) returns read
    * case (all) returns all
 
2. created new route `api/notification/markAllAsRead` that will update all the notifications as read in the database.

3. updated the route `api/notification/updateRead`:
   * accepts an array of ids instead of one
   * can send an satus of `read` `unread` and update accordingly


@Amirat-Alqamar 